### PR TITLE
Uploaded file name fix.

### DIFF
--- a/library/BoxAPI.class.php
+++ b/library/BoxAPI.class.php
@@ -313,10 +313,10 @@ class Box_API
     public function put_file($filename, $name, $parent_id)
     {
         $url = $this->build_url('/files/content', array(), $this->upload_url);
-        if (isset($name)) {
+        if (!isset($name)) {
             $name = basename($filename);
         }
-        $file = new CURLFile($filename);
+        $file = new CURLFile($filename, '', $name);
         $params = array('file' => $file, 'name' => $name, 'parent_id' => $parent_id, 'access_token' => $this->access_token);
         return json_decode($this->post($url, $params), true);
     }


### PR DESCRIPTION
When uploading a file, the name provided didn't get applied to the uploaded file and just used the name of the file being uploaded, whether $name is set or not.